### PR TITLE
Instruction style enforcement checks

### DIFF
--- a/app/playtest/PlaytestCrawler.test.tsx
+++ b/app/playtest/PlaytestCrawler.test.tsx
@@ -91,6 +91,12 @@ describe('PlaytestCrawler', () => {
     it('logs if there are too many consecutive combats'); // 2 combats back-to-back? bad idea. 3 combats with single cards in between? Also bad idea.
 
     it('logs if there is uneven choice distribution') // (too few/too many, or alternating 0-2-0-2 etc.)
+
+    it('logs if instructions involving loot fail to validate');
+
+    it('logs if instructions involving abilities fail to validate');
+
+    it('logs if instructions involving health fail to validate');
   });
 
   describe('info-level message', () => {

--- a/app/playtest/PlaytestCrawler.test.tsx
+++ b/app/playtest/PlaytestCrawler.test.tsx
@@ -97,6 +97,8 @@ describe('PlaytestCrawler', () => {
     it('logs if instructions involving abilities fail to validate');
 
     it('logs if instructions involving health fail to validate');
+
+    it('logs if instructions include reference to "player" or "players"');
   });
 
   describe('info-level message', () => {

--- a/app/playtest/PlaytestCrawler.tsx
+++ b/app/playtest/PlaytestCrawler.tsx
@@ -8,6 +8,17 @@ import {encounters} from 'expedition-app/app/Encounters'
 
 const cheerio: any = require('cheerio') as CheerioAPI;
 
+// Validators for instructions - these look at the preceeding 2 words
+// and expect a <verb> <count> <type> format, where <verb> is something like "gain" or "lose",
+// <count> is a positive integer, and <type> is any of ability/health/loot.
+// These matches are case insensitive and global, using the /gi suffix.
+const HEALTH_INSTRUCTION = /(\w+ \w+ (health|hp))/gi;
+const VALID_HEALTH_INSTRUCTION = /((gain|lose) \d+ health)/i;
+const ABILITY_INSTRUCTION = /(\w+ \w+ abili(ty|ties))/gi;
+const VALID_ABILITY_INSTRUCTION = /((learn|discard) \d+ abili(ty|ties))/i;
+const LOOT_INSTRUCTION = /(\w*\s*\w*\s*\w+ \w+ loot)/gi;
+const VALID_LOOT_INSTRUCTION = /((draw|discard) \d+ tier (I|II|III|IV|V) loot)|(discard \d+ loot)/i;
+
 // Surfaces errors, warnings, statistics, and other useful information
 // about particular states encountered during play through the quest, or
 // about the quest in aggregate.
@@ -20,11 +31,11 @@ export class PlaytestCrawler extends StatsCrawler {
     this.logger = logger;
   }
 
-  public crawlWithLog(node: Node<Context>, logger: Logger): [boolean, number, number] {
+  public crawlWithLog(node: Node<Context>, logger: Logger): [number, number] {
     if (logger) {
       this.logger = logger;
     }
-    const isDone = this.crawl(node);
+    this.crawl(node);
 
     // TODO: We'll probably write a DFS here that traverses the
     // CrawlerStats entries (e.g. for cycle detection)
@@ -33,50 +44,85 @@ export class PlaytestCrawler extends StatsCrawler {
     for (let l of this.statsByEvent['IMPLICIT_END'].lines) {
       this.logger.err('An action on this card leads nowhere (invalid goto id or no **end**)', '430', l);
     }
-    return [isDone, this.queue.length, this.seen.size];
+    return [this.queue.length, this.seen.size];
   }
 
-  // override onNode to track specific per-node bad events
+  // override onNode to validate each node as we see them.
   protected onNode(q: StatsCrawlEntry, nodeStr: string, id: string, line: number): void {
     super.onNode(q, nodeStr, id, line);
 
-    const keys = q.node.getVisibleKeys();
-    const tag = q.node.getTag();
-
-    switch (tag) {
+    switch (q.node.getTag()) {
       case 'combat':
-        const winCount = keys.reduce((acc: number, k: string) => {
-          return acc + ((k === 'win') ? 1 : 0);
-        }, 0);
-        const loseCount = keys.reduce((acc: number, k: string) => {
-          return acc + ((k === 'lose') ? 1 : 0);
-        }, 0);
-        if (winCount !== 1 || loseCount !== 1) {
-          this.logger.err('Detected a state where this card has ' + winCount +
-            ' "win" and ' + loseCount + ' "lose" events; want 1 and 1', '431', line);
-        }
-
-        // Check that enemies are all valid or have tier overrides set.
-        q.node.loopChildren((tag, child, orig) => {
-          if (tag !== 'e') {
-            return;
-          }
-          if (!encounters[child.text().toLowerCase()] && !child.attr('tier')) {
-            this.logger.err('Detected a non-standard enemy "' + child.text() + '" without explicit tier JSON', '419', line);
-          }
-        });
+        this.verifyCombatEventCounts(q.node, line);
+        this.verifyEnemyTiers(q.node, line);
         break;
       case 'roleplay':
-        let choiceCount = 0;
-        q.node.loopChildren((tag, child, orig) => {
-          choiceCount += (tag === 'choice') ? 1 : 0;
-        });
-        if (keys.length === 0 && choiceCount > 0) {
-          this.logger.err('Detected a state where this card has 0 active choices', '432', line);
-        }
+        this.verifyChoiceCount(q.node, line);
+        this.verifyInstructionFormat(q.node, line);
         break;
       default:
         break;
     }
+  }
+
+  private verifyCombatEventCounts(combatNode: Node<Context>, line: number) {
+    const keys = combatNode.getVisibleKeys();
+    const winCount = keys.reduce((acc: number, k: string) => {
+      return acc + ((k === 'win') ? 1 : 0);
+    }, 0);
+    const loseCount = keys.reduce((acc: number, k: string) => {
+      return acc + ((k === 'lose') ? 1 : 0);
+    }, 0);
+    if (winCount !== 1 || loseCount !== 1) {
+      this.logger.err('Detected a state where this card has ' + winCount +
+        ' "win" and ' + loseCount + ' "lose" events; want 1 and 1', '431', line);
+    }
+  }
+
+  private verifyEnemyTiers(combatNode: Node<Context>, line: number) {
+    // Check that enemies are all valid or have tier overrides set.
+    combatNode.loopChildren((tag, child, orig) => {
+      if (tag !== 'e') {
+        return;
+      }
+      if (!encounters[child.text().toLowerCase()] && !child.attr('tier')) {
+        this.logger.err('Detected a non-standard enemy "' + child.text() + '" without explicit tier JSON', '419', line);
+      }
+    });
+  }
+
+  private verifyChoiceCount(roleplayNode: Node<Context>, line: number) {
+    let choiceCount = 0;
+    roleplayNode.loopChildren((tag, child, orig) => {
+      choiceCount += (tag === 'choice') ? 1 : 0;
+    });
+    const keys = roleplayNode.getVisibleKeys();
+    if (keys.length === 0 && choiceCount > 0) {
+      this.logger.err('Detected a state where this card has 0 active choices', '432', line);
+    }
+  }
+
+  private verifyInstructionFormat(roleplayNode: Node<Context>, line: number) {
+    roleplayNode.loopChildren((tag, child, orig) => {
+      if (tag !== 'instruction') {
+        return;
+      }
+      const inst = child.text();
+      for (let m of (inst.match(HEALTH_INSTRUCTION) || [])) {
+        if (!m.match(VALID_HEALTH_INSTRUCTION)) {
+          this.logger.warn('Health-affecting instructions should\nfollow the format "Gain/Lose <number> Health",\ninstead saw "' + m + '"', '429', line);
+        }
+      }
+      for (let m of (inst.match(ABILITY_INSTRUCTION) || [])) {
+        if (!m.match(VALID_ABILITY_INSTRUCTION)) {
+          this.logger.warn('Ability-affecting instructions should\nfollow the format "Learn/Discard <number> Abilit(y/ies)",\ninstead saw "' + m + '"', '429', line);
+        }
+      }
+      for (let m of (inst.match(LOOT_INSTRUCTION) || [])) {
+        if (!m.match(VALID_LOOT_INSTRUCTION)) {
+          this.logger.warn('Loot-affecting instructions should\nread as follows: "Draw 1 Tier IV Loot",\ninstead saw "' + m + '"', '429', line);
+        }
+      }
+    });
   }
 }

--- a/app/playtest/PlaytestCrawler.tsx
+++ b/app/playtest/PlaytestCrawler.tsx
@@ -110,17 +110,17 @@ export class PlaytestCrawler extends StatsCrawler {
       const inst = child.text();
       for (let m of (inst.match(HEALTH_INSTRUCTION) || [])) {
         if (!m.match(VALID_HEALTH_INSTRUCTION)) {
-          this.logger.warn('Health-affecting instructions should\nfollow the format "Gain/Lose <number> Health",\ninstead saw "' + m + '"', '429', line);
+          this.logger.warn('Health-affecting instructions should\nfollow the format "Gain/Lose <number> Health",\ninstead saw "' + m + '"', '434', line);
         }
       }
       for (let m of (inst.match(ABILITY_INSTRUCTION) || [])) {
         if (!m.match(VALID_ABILITY_INSTRUCTION)) {
-          this.logger.warn('Ability-affecting instructions should\nfollow the format "Learn/Discard <number> Abilit(y/ies)",\ninstead saw "' + m + '"', '429', line);
+          this.logger.warn('Ability-affecting instructions should\nfollow the format "Learn/Discard <number> Abilit(y/ies)",\ninstead saw "' + m + '"', '434', line);
         }
       }
       for (let m of (inst.match(LOOT_INSTRUCTION) || [])) {
         if (!m.match(VALID_LOOT_INSTRUCTION)) {
-          this.logger.warn('Loot-affecting instructions should\nread as follows: "Draw 1 Tier IV Loot",\ninstead saw "' + m + '"', '429', line);
+          this.logger.warn('Loot-affecting instructions should\nread as follows: "Draw 1 Tier IV Loot",\ninstead saw "' + m + '"', '434', line);
         }
       }
     });

--- a/app/playtest/PlaytestWorker.tsx
+++ b/app/playtest/PlaytestWorker.tsx
@@ -26,14 +26,12 @@ export function handleMessage(e: {data: {type: 'RUN', timeoutMillis: number, xml
     throw new Error('Invalid element passed to webworker');
   }
   console.log('playtesting...');
-  let hasMore = crawler.crawlWithLog(new Node(elem, defaultContext()), logger);
-  let queueLen = 0;
-  let numSeen = 0;
+  let [queueLen, numSeen] = crawler.crawlWithLog(new Node(elem, defaultContext()), logger);
   maybePublishLog(logger);
 
-  while ((Date.now() - start) < timeout && hasMore) {
+  while ((Date.now() - start) < timeout && queueLen > 0) {
     const logger = new Logger();
-    let [hasMore, queueLen, numSeen] = crawler.crawlWithLog(null, logger);
+    let [queueLen, numSeen] = crawler.crawlWithLog(null, logger);
     console.log('... (queueLen: ' + queueLen, + ', seen ' + numSeen + ')');
     maybePublishLog(logger);
   }

--- a/app/reducers/Annotations.tsx
+++ b/app/reducers/Annotations.tsx
@@ -15,7 +15,7 @@ function toAnnotation(msgs: LogMessage[], result: AnnotationType[], errorLines: 
     result.push({
       row: m.line,
       column: 0,
-      text: m.type + ' ' + m.url + ': ' +m.text,
+      text: m.type[0].toUpperCase() + m.type.substring(1) + ' ' + m.url + ': ' +m.text,
       type: m.type,
     });
   }

--- a/errors/definitions/434.tsx
+++ b/errors/definitions/434.tsx
@@ -18,22 +18,22 @@ export const INVALID = [
 export const VALID = [
 `_A card_
 
-> Draw 1 Tier I loot.
+> Draw one tier I loot.
 
 **end**`,
 `_A card_
 
-> Your party discards 1 loot.
+> Each adventurer: discard 1 loot.
 
 **end**`,
 `_A card_
 
-> You may learn 1 ability
+> You may learn one ability
 
 **end**`,
 `_A card_
 
-> Discard 2 abilities
+> Discard two abilities
 
 **end**`,
 `_A card_

--- a/errors/definitions/434.tsx
+++ b/errors/definitions/434.tsx
@@ -1,0 +1,44 @@
+export const NAME = `Health/Ability/Loot-affecting instructions should follow the format...`;
+export const DESCRIPTION = `Instructions that modify a player's health, ability, and/or loot should follow a standard format.`;
+
+export const TEST_WITH_CRAWLER = true;
+
+export const INVALID = [
+`_A card_
+
+> You get a loot!
+
+**end**`,
+`_A card_
+
+> Heal 5 hp.
+**end**`
+];
+
+export const VALID = [
+`_A card_
+
+> Draw 1 Tier I loot.
+
+**end**`,
+`_A card_
+
+> Your party discards 1 loot.
+
+**end**`,
+`_A card_
+
+> You may learn 1 ability
+
+**end**`,
+`_A card_
+
+> Discard 2 abilities
+
+**end**`,
+`_A card_
+
+> Gain 5 Health.
+
+**end**`,
+];


### PR DESCRIPTION
Also includes a minor cleanup of crawler validation code. This is done via the crawler so we can actually enforce instruction validity even if they're generated via op nodes!

Fixes #341

![lootvalidation](https://user-images.githubusercontent.com/607666/30250650-42492780-9620-11e7-968b-712f464b425f.png)
