### PR TITLE
Annotation details modal

### DIFF
--- a/app/Style.scss
+++ b/app/Style.scss
@@ -92,6 +92,26 @@ body > :first-child:not(#react-app) { display: none; }
   }
 }
 
+.annotation_details {
+  h3 {
+    color: white;
+  }
+
+  .example {
+    background-color: rgba(0,0,0,0.5);
+    padding: $padBase;
+    margin-bottom: $padBase;
+  }
+
+  .reminder {
+    font-style: italic;
+    text-align: center;
+    width: 60%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
 label {
   color: $grey600 !important;
 }

--- a/app/Style.scss
+++ b/app/Style.scss
@@ -109,6 +109,7 @@ body > :first-child:not(#react-app) { display: none; }
     width: 60%;
     margin-left: auto;
     margin-right: auto;
+    margin-bottom: $padBase;
   }
 }
 

--- a/app/actions/ActionTypes.tsx
+++ b/app/actions/ActionTypes.tsx
@@ -22,6 +22,9 @@ export interface SetDialogAction extends Redux.Action {
   type: 'SET_DIALOG';
   dialog: DialogIDType;
   shown: boolean;
+
+  // For annotation detail dialog only
+  annotations?: number[];
 }
 
 export interface SetDirtyAction extends Redux.Action {

--- a/app/actions/Dialogs.test.tsx
+++ b/app/actions/Dialogs.test.tsx
@@ -7,7 +7,8 @@ describe('Dialog action', () => {
       expect(setDialog('ERROR', true)).toEqual({
         type: 'SET_DIALOG',
         dialog: 'ERROR',
-        shown: true
+        shown: true,
+        annotations: undefined,
       } as SetDialogAction);
     });
   });

--- a/app/actions/Dialogs.tsx
+++ b/app/actions/Dialogs.tsx
@@ -3,8 +3,8 @@ import {DialogIDType} from '../reducers/StateTypes'
 
 const ReactGA = require('react-ga') as any;
 
-export function setDialog(dialog: DialogIDType, shown: boolean): SetDialogAction {
-  return {type: 'SET_DIALOG', dialog, shown};
+export function setDialog(dialog: DialogIDType, shown: boolean, annotations?: number[]): SetDialogAction {
+  return {type: 'SET_DIALOG', dialog, shown, annotations};
 }
 
 export function pushHTTPError(err: {statusText: string, status: string, responseText: string}): PushErrorAction {

--- a/app/components/Dialogs.tsx
+++ b/app/components/Dialogs.tsx
@@ -18,6 +18,7 @@ import {QuestType, ShareType, DialogsState, DialogIDType} from '../reducers/Stat
 import theme from '../Theme'
 import {MIN_PLAYERS, MAX_PLAYERS} from '../Constants'
 import {CONTENT_RATINGS, GENRES} from '../../node_modules/expedition-app/app/Constants'
+import {ErrorType} from '../../errors/types'
 
 declare var ga: any;
 
@@ -50,6 +51,72 @@ export class ErrorDialog extends React.Component<ErrorDialogProps, {}> {
         <ul>
           {errors}
         </ul>
+      </Dialog>
+    );
+  }
+}
+
+interface AnnotationDetailDialogProps extends React.Props<any> {
+  open: boolean;
+  annotations: (ErrorType|number)[];
+  onRequestClose: ()=>void;
+}
+
+export class AnnotationDetailDialog extends React.Component<AnnotationDetailDialogProps, {}> {
+  render() {
+    if (!this.props.annotations) {
+      return <span></span>;
+    }
+
+    const missingAnnotations: string = this.props.annotations.filter((v: number|ErrorType) => {
+      return typeof(v) === 'number';
+    }).join(', ');
+
+    const renderedAnnotations: JSX.Element[] = this.props.annotations.filter((v: number | ErrorType) => {
+      return typeof(v) !== 'number';
+    }).map((a: ErrorType, i: number) => {
+      const goodExampleJSX: JSX.Element[] = a.VALID.map((v: string, i: number) => {
+        return <pre className="example" key={i}>{v}</pre>;
+      });
+
+      const badExampleJSX: JSX.Element[] = a.INVALID.map((v: string, i: number) => {
+        return <pre className="example" key={i}>{v}</pre>;
+      });
+
+      return (
+        <div className="annotation" key={i}>
+          <h3>({a.NUMBER}): {a.NAME}</h3>
+          <p>{a.DESCRIPTION}</p>
+          <strong>Good Examples:</strong>
+          <div>{goodExampleJSX}</div>
+          <strong>Invalid Examples</strong>
+          <div>{badExampleJSX}</div>
+        </div>
+       );
+    });
+
+    return (
+      <Dialog
+        title={'Annotation Details'}
+        actions={[
+          <RaisedButton
+            label="OK"
+            primary={true}
+            onTouchTap={() => this.props.onRequestClose()}
+          />,
+        ]}
+        titleClassName={'dialogTitle'}
+        modal={false}
+        autoScrollBodyContent={true}
+        open={Boolean(this.props.open)}>
+        <div className="annotation_details">
+          {renderedAnnotations}
+          {missingAnnotations && <div>Couldn't find info for some annotations: {missingAnnotations}.</div>}
+          <div className="reminder">
+            Remember: You can ask for help at any time using the "Contact us" button at the bottom right
+            of the page.
+          </div>
+        </div>
       </Dialog>
     );
   }
@@ -256,6 +323,11 @@ const Dialogs = (props: DialogsProps): JSX.Element => {
         open={props.dialogs.open['ERROR']}
         onRequestClose={() => props.onRequestClose('ERROR')}
         errors={props.dialogs.errors}
+      />
+      <AnnotationDetailDialog
+        open={props.dialogs.open['ANNOTATION_DETAIL']}
+        onRequestClose={() => props.onRequestClose('ANNOTATION_DETAIL')}
+        annotations={props.dialogs.annotations}
       />
     </span>
   );

--- a/app/components/Dialogs.tsx
+++ b/app/components/Dialogs.tsx
@@ -97,7 +97,7 @@ export class AnnotationDetailDialog extends React.Component<AnnotationDetailDial
 
     return (
       <Dialog
-        title={'Annotation Details'}
+        title={'Message Details'}
         actions={[
           <RaisedButton
             label="OK"
@@ -111,7 +111,7 @@ export class AnnotationDetailDialog extends React.Component<AnnotationDetailDial
         open={Boolean(this.props.open)}>
         <div className="annotation_details">
           {renderedAnnotations}
-          {missingAnnotations && <div>Couldn't find info for some annotations: {missingAnnotations}.</div>}
+          {missingAnnotations && <div className="reminder">Couldn't find info for ID(s): {missingAnnotations}.</div>}
           <div className="reminder">
             Remember: You can ask for help at any time using the "Contact us" button at the bottom right
             of the page.

--- a/app/components/QuestIDE.tsx
+++ b/app/components/QuestIDE.tsx
@@ -17,6 +17,7 @@ export interface QuestIDEStateProps {
 export interface QuestIDEDispatchProps {
   onDirty: (realtime: any, text: string) => void;
   onLine: (line: number) => void;
+  onAnnotationClick: (annotations: number[]) => void;
 }
 
 interface QuestIDEProps extends QuestIDEStateProps, QuestIDEDispatchProps {}
@@ -33,7 +34,8 @@ const QuestIDE = (props: QuestIDEProps): JSX.Element => {
           lastSizeChangeMillis={props.lastSplitPaneDragMillis}
           scrollLineTarget={props.line}
           onChange={(text: string) => props.onDirty(props.realtime, text)}
-          onLine={(line: number) => props.onLine(line)} />
+          onLine={(line: number) => props.onLine(line)}
+          onAnnotationClick={(annotations: number[]) => props.onAnnotationClick(annotations)} />
       </div>
       <div className="preview">
         <AppContainer/>

--- a/app/components/QuestIDEContainer.tsx
+++ b/app/components/QuestIDEContainer.tsx
@@ -4,6 +4,7 @@ import {setLine, updateDirtyState} from '../actions/Editor'
 import {saveQuest} from '../actions/Quest'
 import {AppState, QuestType, EditorState} from '../reducers/StateTypes'
 import QuestIDE, {QuestIDEStateProps, QuestIDEDispatchProps} from './QuestIDE'
+import {setDialog} from '../actions/Dialogs'
 
 const mapStateToProps = (state: AppState, ownProps: any): QuestIDEStateProps => {
   return {
@@ -24,6 +25,9 @@ const mapDispatchToProps = (dispatch: Redux.Dispatch<any>, ownProps: any): Quest
     onLine: (line: number) => {
       dispatch(setLine(line));
     },
+    onAnnotationClick: (annotations: number[]) => {
+      dispatch(setDialog('ANNOTATION_DETAIL', true, annotations));
+    }
   };
 }
 

--- a/app/reducers/Annotations.tsx
+++ b/app/reducers/Annotations.tsx
@@ -49,7 +49,7 @@ export function annotations(state: AnnotationType[] = [], action: Redux.Action):
     result.push({
       row: l,
       column: 0,
-      text: '(See HELP for more details)',
+      text: '(Click the icon for details)',
       type: 'info',
     });
   });

--- a/app/reducers/Dialogs.tsx
+++ b/app/reducers/Dialogs.tsx
@@ -1,11 +1,26 @@
 import Redux from 'redux'
 import {SetDialogAction, PushErrorAction} from '../actions/ActionTypes'
 import {DialogsState} from './StateTypes'
+import errors from '../../errors/errors'
 
-const initialState: DialogsState = {open: {USER: false,  ERROR: false, PUBLISHED: false, UNPUBLISHED: false}, errors: []};
+const initialState: DialogsState = {
+  open: {
+    USER: false,
+    ERROR: false,
+    PUBLISHED: false,
+    UNPUBLISHED: false,
+    ANNOTATION_DETAIL: false
+  },
+  errors: [],
+  annotations: null,
+};
 
 export function dialogs(state: DialogsState = initialState, action: Redux.Action): DialogsState {
-  let newState: DialogsState = {open: {...state.open}, errors: [...state.errors]};
+  let newState: DialogsState = {
+    open: {...state.open},
+    errors: [...state.errors],
+    annotations: state.annotations
+  };
   switch (action.type) {
     case 'SET_DIALOG':
       let dialog_action = (action as SetDialogAction);
@@ -15,6 +30,16 @@ export function dialogs(state: DialogsState = initialState, action: Redux.Action
       if (dialog_action.dialog === 'ERROR' && !dialog_action.shown) {
         newState.errors = [];
       }
+
+      // Assign the appropriate error details when showing annotation details dialog
+      if (dialog_action.dialog === 'ANNOTATION_DETAIL') {
+        if (dialog_action.shown) {
+          newState.annotations = dialog_action.annotations.map((a: number) => {return errors[a] || a});
+        } else {
+          newState.annotations = null;
+        }
+      }
+
       return newState;
     case 'QUEST_PUBLISHING_SETUP':
       newState.open.PUBLISHING = true;

--- a/app/reducers/StateTypes.tsx
+++ b/app/reducers/StateTypes.tsx
@@ -1,8 +1,9 @@
 import {AppStateWithHistory} from 'expedition-app/app/reducers/StateTypes'
 import {QDLParser} from 'expedition-qdl/lib/render/QDLParser'
+import {ErrorType} from '../../errors/types'
 // TODO: URL type?
 
-export type DialogIDType = 'ERROR' | 'PUBLISHING' | 'UNPUBLISHED';
+export type DialogIDType = 'ERROR' | 'ANNOTATION_DETAIL' | 'PUBLISHING' | 'UNPUBLISHED';
 
 export type ShareType = 'PRIVATE' | 'UNLISTED' | 'PUBLIC';
 
@@ -84,6 +85,7 @@ export interface DialogsState {
     [key: string]: boolean;
   }
   errors: Error[];
+  annotations: (ErrorType|number)[];
 }
 
 export interface SnackbarState {

--- a/errors/definitions/411.tsx
+++ b/errors/definitions/411.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 411;
-export const NAME = `roleplay blocks cannot contain indented sections that are not choices`;
+export const NAME = `Roleplay blocks cannot contain indented sections that are not choices`;
 export const DESCRIPTION = `Indentation is used to keep track of branches, which are created by choices and events.
 If you want to create a branch, use one of those elements.`;
 

--- a/errors/definitions/411.tsx
+++ b/errors/definitions/411.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 411;
 export const NAME = `roleplay blocks cannot contain indented sections that are not choices`;
 export const DESCRIPTION = `Indentation is used to keep track of branches, which are created by choices and events.
 If you want to create a branch, use one of those elements.`;

--- a/errors/definitions/412.tsx
+++ b/errors/definitions/412.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 412;
 export const NAME = `failed to parse bulleted line (check your JSON)`;
 export const DESCRIPTION = `Bulleted lines (such as combat events) often have JSON strings after them.
 In this case, the compiler found a JSON-like string and failed to parse it`;

--- a/errors/definitions/412.tsx
+++ b/errors/definitions/412.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 412;
-export const NAME = `failed to parse bulleted line (check your JSON)`;
+export const NAME = `Failed to parse bulleted line (check your JSON)`;
 export const DESCRIPTION = `Bulleted lines (such as combat events) often have JSON strings after them.
 In this case, the compiler found a JSON-like string and failed to parse it`;
 

--- a/errors/definitions/413.tsx
+++ b/errors/definitions/413.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 413;
 export const NAME = `could not parse block header`;
 export const DESCRIPTION = `Generally caused by an invalid JSON annotation`;
 

--- a/errors/definitions/413.tsx
+++ b/errors/definitions/413.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 413;
-export const NAME = `could not parse block header`;
+export const NAME = `Could not parse block header`;
 export const DESCRIPTION = `Generally caused by an invalid JSON annotation`;
 
 export const INVALID = [

--- a/errors/definitions/414.tsx
+++ b/errors/definitions/414.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 414;
 export const NAME = `combat card has no enemies listed`;
 export const DESCRIPTION = ``;
 

--- a/errors/definitions/414.tsx
+++ b/errors/definitions/414.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 414;
-export const NAME = `combat card has no enemies listed`;
+export const NAME = `Combat card has no enemies listed`;
 export const DESCRIPTION = ``;
 
 export const INVALID = [

--- a/errors/definitions/415.tsx
+++ b/errors/definitions/415.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 415;
-export const NAME = `found inner block of combat block without an event bullet`;
+export const NAME = `Found inner block of combat block without an event bullet`;
 export const DESCRIPTION = ``;
 
 export const INVALID = [

--- a/errors/definitions/415.tsx
+++ b/errors/definitions/415.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 415;
 export const NAME = `found inner block of combat block without an event bullet`;
 export const DESCRIPTION = ``;
 

--- a/errors/definitions/416.tsx
+++ b/errors/definitions/416.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 416;
-export const NAME = `lines within combat block must be events or enemies, not freestanding text`;
+export const NAME = `Lines within combat block must be events or enemies, not freestanding text`;
 export const DESCRIPTION = ``;
 
 export const INVALID = [

--- a/errors/definitions/416.tsx
+++ b/errors/definitions/416.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 416;
 export const NAME = `lines within combat block must be events or enemies, not freestanding text`;
 export const DESCRIPTION = ``;
 

--- a/errors/definitions/417.tsx
+++ b/errors/definitions/417.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 417;
 export const NAME = `combat card must have '<on win/on lose>' event`;
 export const DESCRIPTION = ``;
 

--- a/errors/definitions/417.tsx
+++ b/errors/definitions/417.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 417;
-export const NAME = `combat card must have '<on win/on lose>' event`;
+export const NAME = `Combat card must have '<on win/on lose>' event`;
 export const DESCRIPTION = ``;
 
 export const INVALID = [

--- a/errors/definitions/418.tsx
+++ b/errors/definitions/418.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 418;
 export const NAME = `Tier must be a number between 1 and 9, inclusive`;
 export const DESCRIPTION = `A tier was specified that was either not a number, or not within the range of valid tiers.`;
 

--- a/errors/definitions/419.tsx
+++ b/errors/definitions/419.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 419;
 export const NAME = `Detected a non-standard enemy without explicit tier JSON`;
 export const DESCRIPTION = `An enemy was listed that is not part of the standard deck of enemies, without a tier specified.
 This may be a spelling/capitalization error.`;

--- a/errors/definitions/420.tsx
+++ b/errors/definitions/420.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 420;
-export const NAME = `invalid quest attribute line "<text>"`;
+export const NAME = `Invalid quest attribute line "<text>"`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = ``;
 

--- a/errors/definitions/420.tsx
+++ b/errors/definitions/420.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 420;
 export const NAME = `invalid quest attribute line "<text>"`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = ``;
@@ -14,7 +15,7 @@ maxtimeminutes: 10`
 ];
 
 export const INVALID_ERRORS = [
-"invalid quest attribute line \"text that doesn't belong here\""
+`invalid quest attribute line "text that doesn't belong here"`
 ]
 
 export const VALID = [

--- a/errors/definitions/421.tsx
+++ b/errors/definitions/421.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 421;
-export const NAME = `root block must be a quest header`;
+export const NAME = `Root block must be a quest header`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = ``;
 

--- a/errors/definitions/421.tsx
+++ b/errors/definitions/421.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 421;
 export const NAME = `root block must be a quest header`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = ``;

--- a/errors/definitions/422.tsx
+++ b/errors/definitions/422.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 422;
-export const NAME = `no quest blocks found`;
+export const NAME = `No quest blocks found`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = ``;
 

--- a/errors/definitions/422.tsx
+++ b/errors/definitions/422.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 422;
 export const NAME = `no quest blocks found`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = ``;

--- a/errors/definitions/423.tsx
+++ b/errors/definitions/423.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 423;
-export const NAME = `quest block group cannot contain multiple blocks`;
+export const NAME = `Quest block group cannot contain multiple blocks`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = ``;
 

--- a/errors/definitions/423.tsx
+++ b/errors/definitions/423.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 423;
 export const NAME = `quest block group cannot contain multiple blocks`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = ``;

--- a/errors/definitions/424.tsx
+++ b/errors/definitions/424.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 424;
 export const NAME = `missing: "<key>"`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = `You're missing the specified metadata key, which is required for quests.`;

--- a/errors/definitions/424.tsx
+++ b/errors/definitions/424.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 424;
-export const NAME = `missing: "<key>"`;
+export const NAME = `Missing: "<key>"`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = `You're missing the specified metadata key, which is required for quests.`;
 

--- a/errors/definitions/426.tsx
+++ b/errors/definitions/426.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 426;
 export const NAME = `<key> should be a number, but is <type>`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = `The quest metadata key you're trying to use must be a number.`;

--- a/errors/definitions/427.tsx
+++ b/errors/definitions/427.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 427;
 export const NAME = `unknown key: <key>`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = `The quest metadata key you're trying to use must be a number.`;

--- a/errors/definitions/427.tsx
+++ b/errors/definitions/427.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 427;
-export const NAME = `unknown key: <key>`;
+export const NAME = `Unknown key: <key>`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = `The quest metadata key you're trying to use must be a number.`;
 

--- a/errors/definitions/428.tsx
+++ b/errors/definitions/428.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 428;
 export const NAME = `choice missing title`;
 export const DESCRIPTION = `All choices need titles, which is used as the label for adventurers to click on.`;
 

--- a/errors/definitions/428.tsx
+++ b/errors/definitions/428.tsx
@@ -1,5 +1,5 @@
 export const NUMBER = 428;
-export const NAME = `choice missing title`;
+export const NAME = `Choice missing title`;
 export const DESCRIPTION = `All choices need titles, which is used as the label for adventurers to click on.`;
 
 export const INVALID = [

--- a/errors/definitions/429.tsx
+++ b/errors/definitions/429.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 429;
 export const NAME = `Quest attributes have migrated to the "Publish" button`;
 export const METADATA_ERROR = true;
 export const DESCRIPTION = `Simply delete existing metadata (except title)`;

--- a/errors/definitions/430.tsx
+++ b/errors/definitions/430.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 430;
 export const NAME = `An action on this card leads nowhere (invalid goto id or no **end**)`;
 export const DESCRIPTION = `Your card has no next choice, nor does it end the quest.`;
 

--- a/errors/definitions/431.tsx
+++ b/errors/definitions/431.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 431;
 export const NAME = `Detected a state where this card has # "win" and # "lose" events; want 1 and 1`;
 export const DESCRIPTION = `Some path to this combat card results in an incorrect number of win and lose events. There must be exactly one of each.`;
 

--- a/errors/definitions/432.tsx
+++ b/errors/definitions/432.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 432;
 export const NAME = `Detected a state where this card has 0 active choices`;
 export const DESCRIPTION = `Some path to this card results in no defined choices.`;
 

--- a/errors/definitions/433.tsx
+++ b/errors/definitions/433.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 433;
 export const NAME = `Card title too long`;
 export const DESCRIPTION = `Card titles may not be 25 characters or longer.`;
 

--- a/errors/definitions/434.tsx
+++ b/errors/definitions/434.tsx
@@ -1,3 +1,4 @@
+export const NUMBER = 434;
 export const NAME = `Health/Ability/Loot-affecting instructions should follow the format...`;
 export const DESCRIPTION = `Instructions that modify a player's health, ability, and/or loot should follow a standard format.`;
 

--- a/errors/errors.tsx
+++ b/errors/errors.tsx
@@ -22,6 +22,7 @@ import * as e430 from './definitions/430'
 import * as e431 from './definitions/431'
 import * as e432 from './definitions/432'
 import * as e433 from './definitions/433'
+import * as e434 from './definitions/434'
 
 const errors: {[id: number]: ErrorType} = {
   411: e411,
@@ -46,6 +47,7 @@ const errors: {[id: number]: ErrorType} = {
   431: e431,
   432: e432,
   433: e433,
+  434: e434,
 };
 
 // TODO(scott): Bulk-rename all this to "annotation" instead of "error"

--- a/errors/errors.tsx
+++ b/errors/errors.tsx
@@ -1,16 +1,52 @@
 import {ErrorType} from './types'
 
-const Fs: any = require('fs');
+import * as e411 from './definitions/411'
+import * as e412 from './definitions/412'
+import * as e413 from './definitions/413'
+import * as e414 from './definitions/414'
+import * as e415 from './definitions/415'
+import * as e416 from './definitions/416'
+import * as e417 from './definitions/417'
+import * as e418 from './definitions/418'
+import * as e419 from './definitions/419'
+import * as e420 from './definitions/420'
+import * as e421 from './definitions/421'
+import * as e422 from './definitions/422'
+import * as e423 from './definitions/423'
+import * as e424 from './definitions/424'
+import * as e426 from './definitions/426'
+import * as e427 from './definitions/427'
+import * as e428 from './definitions/428'
+import * as e429 from './definitions/429'
+import * as e430 from './definitions/430'
+import * as e431 from './definitions/431'
+import * as e432 from './definitions/432'
+import * as e433 from './definitions/433'
 
-declare var exports: ErrorType[];
+const errors: {[id: number]: ErrorType} = {
+  411: e411,
+  412: e412,
+  413: e413,
+  414: e414,
+  415: e415,
+  416: e416,
+  417: e417,
+  418: e418,
+  419: e419,
+  420: e420,
+  421: e421,
+  422: e422,
+  423: e423,
+  424: e424,
+  426: e426,
+  427: e427,
+  428: e428,
+  429: e429,
+  430: e430,
+  431: e431,
+  432: e432,
+  433: e433,
+};
 
-
-const errors: string[] = Fs.readdirSync('./errors/definitions');
-
-errors.forEach((err) => {
-  const Err: ErrorType = Object.assign({},
-    (require('./definitions/' + err) as ErrorType),
-    {NUMBER: Number(err.replace('.tsx', ''))}
-  );
-  exports[Err.NUMBER] = Err;
-});
+// TODO(scott): Bulk-rename all this to "annotation" instead of "error"
+export default errors;

--- a/errors/types.tsx
+++ b/errors/types.tsx
@@ -1,10 +1,13 @@
-export interface ErrorType {
+export type ErrorType = {
   NUMBER: number;
   NAME: string;
-  METADATA_ERROR?: boolean;
   DESCRIPTION: string;
   INVALID: string[];
   INVALID_ERRORS?: string[]; // array of custom errors to match with INVALID
                              // can set individual entries to null to match against standard error
   VALID: string[];
-}
+
+  // Additional details on the error
+  METADATA_ERROR?: boolean;
+  AFFECTED_BY_OPS?: boolean;
+};


### PR DESCRIPTION
* Auto-loads from error definitions when gutter icon is clicked
* Includes suggestion to contact if blocked by errors
* Error loading was changed from using `fs` since this cannot be done in webpack/browser environment.
![annotations](https://user-images.githubusercontent.com/607666/30251929-9e277824-9637-11e7-8b19-34c27e04f7c9.png)


Closes https://github.com/ExpeditionRPG/expedition-quest-creator/issues/271
Closes https://github.com/ExpeditionRPG/expedition-quest-creator/issues/343