### PR TITLE
show loading hint on slow / failed load; remove per-quest email field

### DIFF
--- a/app/Style.scss
+++ b/app/Style.scss
@@ -126,9 +126,21 @@ label {
   height: 100%;
   text-align: center;
   color: white;
-  padding: $padBase;
+  padding: 2*$padBase;
   font-family: $fontFamilyHeader;
   font-weight: bold;
+
+  .fadeIn {
+    opacity: 0;
+    padding-top: 2*$padBase;
+    font-family: $fontFamilyBody;
+    font-weight: normal;
+    max-width: 720px;
+    margin: 0 auto;
+    animation: fadein 1s;
+    animation-delay: 2s;
+    animation-fill-mode: forwards;
+  }
 }
 
 .saveIndicator {
@@ -653,4 +665,33 @@ body .olark-launch-button { /*must be more specifc than olark styles */
     list-style:none;
     padding-left: 0;
   }
+}
+
+@keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+/* Firefox < 16 */
+@-moz-keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+/* Safari, Chrome and Opera > 12.1 */
+@-webkit-keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+/* Internet Explorer */
+@-ms-keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+/* Opera < 12.1 */
+@-o-keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
 }

--- a/app/components/Dialogs.tsx
+++ b/app/components/Dialogs.tsx
@@ -14,7 +14,7 @@ import TextField from 'material-ui/TextField'
 import Toggle from 'material-ui/Toggle'
 
 import Checkbox from './base/Checkbox'
-import {QuestType, ShareType, DialogsState, DialogIDType} from '../reducers/StateTypes'
+import {QuestType, ShareType, DialogsState, DialogIDType, UserState} from '../reducers/StateTypes'
 import theme from '../Theme'
 import {MIN_PLAYERS, MAX_PLAYERS} from '../Constants'
 import {CONTENT_RATINGS, GENRES} from '../../node_modules/expedition-app/app/Constants'
@@ -132,6 +132,7 @@ interface PublishingDialogProps extends React.Props<any> {
   onRequestClose: () => void;
   onRequestPublish: (quest: QuestType, majorRelease: boolean, privatePublish: boolean) => void;
   quest: QuestType;
+  user: UserState;
 }
 
 export class PublishingDialog extends React.Component<PublishingDialogProps, {}> {
@@ -197,12 +198,6 @@ export class PublishingDialog extends React.Component<PublishingDialogProps, {}>
           value={metadata.get('author')}
           floatingLabelText="Author name"
           onChange={(e: any, val: string) => { this.props.handleMetadataChange(this.props.quest, 'author', val); }}
-        />
-        <TextField
-          className="halfWidth"
-          value={metadata.get('email')}
-          floatingLabelText="Contact email (private)"
-          onChange={(e: any, val: string) => { this.props.handleMetadataChange(this.props.quest, 'email', val); }}
         />
         <SelectField
           className="halfWidth"
@@ -302,6 +297,7 @@ export class PublishingDialog extends React.Component<PublishingDialogProps, {}>
 export interface DialogsStateProps {
   dialogs: DialogsState;
   quest: QuestType;
+  user: UserState;
 };
 
 export interface DialogsDispatchProps {
@@ -322,6 +318,7 @@ const Dialogs = (props: DialogsProps): JSX.Element => {
         onRequestClose={() => props.onRequestClose('PUBLISHING')}
         onRequestPublish={props.onRequestPublish}
         quest={props.quest}
+        user={props.user}
       />
       <ErrorDialog
         open={props.dialogs.open['ERROR']}

--- a/app/components/DialogsContainer.tsx
+++ b/app/components/DialogsContainer.tsx
@@ -14,6 +14,7 @@ const mapStateToProps = (state: AppState, ownProps: any): DialogsStateProps => {
   return {
     dialogs: state.dialogs,
     quest: state.quest,
+    user: state.user,
   };
 }
 

--- a/app/components/Main.tsx
+++ b/app/components/Main.tsx
@@ -37,6 +37,9 @@ const Main = (props: MainProps): JSX.Element => {
     return (
       <div className="main loading">
         Loading Expedition Quest Creator...
+        <div className="fadeIn">
+          Not loading? Try disabling your ad blocker. If that doesn't work, hit the "Contact Us" button in the bottom right - make sure to include the title of your quest.
+        </div>
       </div>
     );
   } else if (props.loggedIn === false || Object.keys(props.quest).length === 0) {

--- a/app/reducers/User.tsx
+++ b/app/reducers/User.tsx
@@ -7,6 +7,7 @@ const default_state: UserState = {
   id: null,
   displayName: null,
   image: null,
+  email: null,
 };
 
 export function user(state: UserState = default_state, action: Redux.Action): UserState {


### PR DESCRIPTION
Since account email is pre-populated from Google with >99% of users, think it's useful to build a consistency to use the account email address for quests so that there's no confusion or chance of typos. If we're concerned about this, we could instead show a help text that says "email is now changed in account settings", and add a little account settings / email change thing to the top right.

<img width="959" alt="screen shot 2017-12-22 at 11 19 53" src="https://user-images.githubusercontent.com/775657/34310072-416a8d3c-e70a-11e7-99fa-cc82a6e6f591.png">