### PR TITLE
Updated QDL version; added qdl-removed art check into playtest crawler

### DIFF
--- a/app/playtest/PlaytestCrawler.test.tsx
+++ b/app/playtest/PlaytestCrawler.test.tsx
@@ -68,6 +68,8 @@ describe('PlaytestCrawler', () => {
       expect(msgs.error[0].text).toContain('2 "win" and 0 "lose" events');
     });
 
+    it('logs if a node contains an [art] tag not on its own line');
+
     it('logs if a node has all choices hidden and "Next" is shown', () => {
 
     }); // (correctness depends on user intent here)

--- a/app/playtest/PlaytestCrawler.tsx
+++ b/app/playtest/PlaytestCrawler.tsx
@@ -64,14 +64,14 @@ export class PlaytestCrawler extends StatsCrawler {
       case 'roleplay':
         this.verifyChoiceCount(q.node, line);
         this.verifyInstructionFormat(q.node, line);
-        this.verifyRoleplayIconsAndArt(q.node, line);
+        this.verifyRoleplayArt(q.node, line);
         break;
       default:
         break;
     }
   }
 
-  private verifyRoleplayIconsAndArt(roleplayNode: Node<Context>, line: number) {
+  private verifyRoleplayArt(roleplayNode: Node<Context>, line: number) {
     roleplayNode.loopChildren((tag, child, orig) => {
       const inst = child.text();
       const invalidArt = REGEX.INVALID_ART.exec(inst);

--- a/app/playtest/PlaytestCrawler.tsx
+++ b/app/playtest/PlaytestCrawler.tsx
@@ -6,6 +6,7 @@ import {Node} from 'expedition-qdl/lib/parse/Node'
 import {Logger, LogMessageMap} from 'expedition-qdl/lib/render/Logger'
 import {initQuest} from 'expedition-app/app/actions/Quest'
 import {encounters} from 'expedition-app/app/Encounters'
+import REGEX from 'expedition-qdl/lib/Regex'
 
 const cheerio: any = require('cheerio') as CheerioAPI;
 
@@ -63,10 +64,22 @@ export class PlaytestCrawler extends StatsCrawler {
       case 'roleplay':
         this.verifyChoiceCount(q.node, line);
         this.verifyInstructionFormat(q.node, line);
+        this.verifyRoleplayIconsAndArt(q.node, line);
         break;
       default:
         break;
     }
+  }
+
+  private verifyRoleplayIconsAndArt(roleplayNode: Node<Context>, line: number) {
+    roleplayNode.loopChildren((tag, child, orig) => {
+      const inst = child.text();
+      const invalidArt = REGEX.INVALID_ART.exec(inst);
+      if (invalidArt) {
+        this.logger.err(`[${invalidArt[1]}] should be on its own line`, '435', line);
+      }
+    });
+
   }
 
   private verifyCombatEventCounts(combatNode: Node<Context>, line: number) {
@@ -135,6 +148,7 @@ export class PlaytestCrawler extends StatsCrawler {
           this.logger.warn('Loot-affecting instructions should\nread as follows: "Draw (one/two/three/four/five/six) tier (I/II/III/IV/V) loot",\ninstead saw "' + m + '"', '434', line);
         }
       }
+
       const badPlayerReferences = (inst.match(ADVENTURER_INSTRUCTION) || []).map((m: string) => {
         return '"' + m.replace('"', '\'') + '"';
       }).join(', ');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cheerio": "^0.22.0",
     "copy-webpack-plugin": "^4.0.1",
     "expedition-app": "git+https://github.com/ExpeditionRPG/expedition-app.git#81389130b714d96330944fc4fa459ce38596f6bd",
-    "expedition-qdl": "git+https://github.com/ExpeditionRPG/expedition-qdl.git#158a3fb41cae75d1509b110120fc7013053e2016",
+    "expedition-qdl": "git+https://github.com/ExpeditionRPG/expedition-qdl.git#5c5008f3df2c56f883a862e8630fd18b873ebda9",
     "forwarded": "^0.1.0",
     "google-auth-library": "^0.10.0",
     "google-url": "0.0.4",


### PR DESCRIPTION
#459 

Now correctly checks for `[art]` tags being on a single line, even when generated via op node.